### PR TITLE
パース処理の改善

### DIFF
--- a/lib/block_node_handler.rb
+++ b/lib/block_node_handler.rb
@@ -1,0 +1,42 @@
+# ブロック要素の処理
+
+class BlockNodeHandler
+
+  def self.add_to(dom_handler, tag, block_node_style)
+    handler = self.new(block_node_style)
+    dom_handler.register_node_handler(tag, handler)
+    handler
+  end
+
+  def initialize(block_node_style)
+    @style = block_node_style
+    @dom_handler = nil
+  end
+
+  attr_writer :dom_handler
+
+  def handle_node(block_node, typeset_document)
+    if @style.begin_new_page? && (! typeset_document.current_page.empty?)
+      @dom_handler.create_new_page(typeset_document)
+    end
+
+    box = typeset_document.current_page.new_box(@style.margin, @style.padding, @style.line_gap)
+    line = box.new_line
+    font = TypesetFont.new(@style.sfnt_font, @style.font_size)
+    line.push font.get_font_set_operation
+    if @style.indent != 0
+      line.push font.get_space(@style.indent) # 行頭インデント
+    end
+
+    @dom_handler.stack_font(font) do
+      block_node.each do |child|
+        @dom_handler.dispatch_node_handling(child, typeset_document)
+      end
+    end
+  end
+
+end
+
+if __FILE__ == $0
+  # FIXME: 動作確認のコードを追加すること
+end

--- a/lib/block_node_handler.rb
+++ b/lib/block_node_handler.rb
@@ -1,5 +1,7 @@
 # ブロック要素の処理
 
+require_relative 'typeset_font'
+
 class BlockNodeHandler
 
   def self.add_to(dom_handler, tag, block_node_style)

--- a/lib/block_node_handler.rb
+++ b/lib/block_node_handler.rb
@@ -3,17 +3,15 @@
 class BlockNodeHandler
 
   def self.add_to(dom_handler, tag, block_node_style)
-    handler = self.new(block_node_style)
+    handler = self.new(dom_handler, block_node_style)
     dom_handler.register_node_handler(tag, handler)
     handler
   end
 
-  def initialize(block_node_style)
+  def initialize(dom_handler, block_node_style)
+    @dom_handler = dom_handler
     @style = block_node_style
-    @dom_handler = nil
   end
-
-  attr_writer :dom_handler
 
   def handle_node(block_node, typeset_document)
     if @style.begin_new_page? && (! typeset_document.current_page.empty?)

--- a/lib/block_node_style.rb
+++ b/lib/block_node_style.rb
@@ -1,0 +1,24 @@
+# ブロック要素のスタイル
+
+require_relative 'typeset_margin'
+require_relative 'typeset_padding'
+
+class BlockNodeStyle
+
+  def initialize
+    @sfnt_font = nil
+    @font_size = nil
+    @line_gap = 0
+    @margin = TypesetMargin.zero_margin
+    @padding = TypesetPadding.zero_padding
+    @begin_new_page = false
+    @indent = 0
+  end
+
+  attr_accessor :sfnt_font, :font_size
+  attr_accessor :line_gap, :margin, :padding
+  attr_accessor :begin_new_page
+  alias_method :begin_new_page?, :begin_new_page
+  attr_accessor :indent
+
+end

--- a/lib/dom_handler.rb
+++ b/lib/dom_handler.rb
@@ -2,6 +2,8 @@
 
 require 'ox'
 
+require_relative 'typeset_font'
+
 class DomHandler
 
   # 未登録のノードを処理する
@@ -14,13 +16,15 @@ class DomHandler
 
   end
 
-  def initialize(default_font)
+  def initialize(default_sfnt_font, default_font_size)
     @node_handlers = {}
     @text_handler = nil
     @page_handler = nil
     @unknown_node_handler = UnknownNodeHandler.new
+
     # FIXME: text handlerがボックスの設定を参照できるようにした方がよさそう
     # chain of responsibilityで上位に問い合わせていく
+    default_font = TypesetFont.new(default_sfnt_font, default_font_size)
     @typeset_font_stack = [default_font]
     @ignore_line_feed = true
   end
@@ -128,7 +132,7 @@ if __FILE__ == $0
 
   end
 
-  dom_handler = DomHandler.new(nil) # ここではfontは使わない
+  dom_handler = DomHandler.new(nil, nil) # ここではfontは使わない
   PrintNodeHandler.add_to(dom_handler, "h1")
   PrintNodeHandler.add_to(dom_handler, "p")
   PrintNodeHandler.add_to(dom_handler, "text")

--- a/lib/dom_handler.rb
+++ b/lib/dom_handler.rb
@@ -1,0 +1,109 @@
+# DOMから組版オブジェクトを組み立てる
+
+require 'ox'
+
+class DomHandler
+
+  # 未登録のノードを処理する
+  class UnknownNodeHandler
+
+    def handle_node(node, typeset_document)
+      unknown_value = node.is_a?(Ox::Node) ? node.value : node
+      puts "[unknown] #{unknown_value}"
+    end
+
+  end
+
+  def initialize
+    @node_handlers = {}
+    @text_handler = nil
+    @unknown_node_handler = UnknownNodeHandler.new
+  end
+
+  def register_node_handler(tag, node_handler)
+    @node_handlers[tag] = node_handler
+    node_handler.dom_handler = self
+  end
+
+  def register_text_handler(text_handler)
+    @text_handler = text_handler
+    text_handler.dom_handler = self
+  end
+
+  def handle_dom(dom, typeset_document)
+    dom.each do |node|
+      dispatch_node_handling(node, typeset_document)
+    end
+  end
+
+  def dispatch_node_handling(node, typeset_document)
+    if node.is_a?(Ox::Node)
+      tag = node.value
+      node_handler = @node_handlers[tag] || @unknown_node_handler
+      node_handler.handle_node(node, typeset_document)
+    elsif node.is_a?(String)
+      text_handler = @text_handler || @unknown_node_handler
+      text_handler.handle_node(node, typeset_document)
+    else
+      @unknown_node_handler.handle_node(node.to_s, typeset_document)
+    end
+  end
+
+  # フォントを設定してブロック処理をする
+  # 改行の扱いを設定してブロック処理する
+  # とかもあるとよさそう
+  # dom_handler.with_font(font) do
+  #   ...
+  # end
+  # みたいな
+
+end
+
+if __FILE__ == $0
+  class PrintHandler
+
+    def self.add_to_dom_handler(dom_handler, value)
+      if value == "text"
+        text_handler = self.new
+        dom_handler.register_text_handler(text_handler)
+      else
+        node_handler = self.new
+        dom_handler.register_node_handler(value, node_handler)
+      end
+    end
+
+    def initialize
+      @dom_handler = nil
+    end
+
+    attr_accessor :dom_handler
+
+    def handle_node(node, typeset_document)
+      if node.is_a?(Ox::Node)
+        puts "[node] #{node.value}"
+        node.each do |child|
+          @dom_handler.dispatch_node_handling(child, typeset_document)
+        end
+      else
+        puts "[text] #{node}"
+      end
+    end
+
+  end
+
+  dom_handler = DomHandler.new
+  PrintHandler.add_to_dom_handler(dom_handler, "h1")
+  PrintHandler.add_to_dom_handler(dom_handler, "p")
+  PrintHandler.add_to_dom_handler(dom_handler, "text")
+
+  dom = Ox.load(<<~END_OF_HTML)
+    <body>
+      <h1>hoge</h1>
+      xxx
+      <p>hugahuga</p>
+      <p>huga<strong>hoge</strong>huga</p>
+    </body>
+  END_OF_HTML
+
+  dom_handler.handle_dom(dom, nil)
+end

--- a/lib/dom_handler.rb
+++ b/lib/dom_handler.rb
@@ -14,11 +14,12 @@ class DomHandler
 
   end
 
-  def initialize
+  def initialize(default_font)
     @node_handlers = {}
     @text_handler = nil
     @page_handler = nil
     @unknown_node_handler = UnknownNodeHandler.new
+    @typeset_font_stack = [default_font]
   end
 
   def register_node_handler(tag, node_handler)
@@ -56,6 +57,16 @@ class DomHandler
 
   def create_new_page(typeset_document)
     @page_handler.create_new_page(typeset_document)
+  end
+
+  def stack_font(typeset_font, &block)
+    @typeset_font_stack.push typeset_font
+    block.call
+    @typeset_font_stack.pop
+  end
+
+  def current_font
+    @typeset_font_stack[-1]
   end
 
   # フォントを設定してブロック処理をする
@@ -120,7 +131,7 @@ if __FILE__ == $0
 
   end
 
-  dom_handler = DomHandler.new
+  dom_handler = DomHandler.new(nil) # ここではfontは使わない
   PrintNodeHandler.add_to(dom_handler, "h1")
   PrintNodeHandler.add_to(dom_handler, "p")
   PrintNodeHandler.add_to(dom_handler, "text")

--- a/lib/inline_node_handler.rb
+++ b/lib/inline_node_handler.rb
@@ -1,0 +1,42 @@
+# インライン要素の処理
+
+class InlineNodeHandler
+
+  def self.add_to(dom_handler, tag, inline_node_style)
+    handler = self.new(dom_handler, inline_node_style)
+    dom_handler.register_node_handler(tag, handler)
+    handler
+  end
+
+  def initialize(dom_handler, inline_node_style)
+    @dom_handler = dom_handler
+    @style = inline_node_style
+  end
+
+  def handle_node(inline_node, typeset_document)
+    line = document.current_page.current_box.current_line
+    prev_font = @dom_handler.current_font
+    font = TypesetFont.new(@style.sfnt_font, prev_font.size)
+    line.push font.get_font_set_operation
+
+    prev_ignore_line_feed = @dom_handler.ignore_line_feed
+    @dom_handler.ignore_line_feed = @style.ignore_line_feed
+
+    @dom_handler.stack_font(font) do
+      # inline_nodeの下はstringのみ
+      inline_node.each do |string|
+        @dom_handler.dispatch_node_handling(string, document)
+      end
+    end
+
+    @dom_handler.ignore_line_feed = prev_ignore_line_feed
+
+    line = document.current_page.current_box.current_line
+    line.push prev_font.get_font_set_operation
+  end
+
+end
+
+if __FILE__ == $0
+  # FIXME: 動作確認のコードを追加すること
+end

--- a/lib/inline_node_handler.rb
+++ b/lib/inline_node_handler.rb
@@ -1,5 +1,7 @@
 # インライン要素の処理
 
+require_relative 'typeset_font'
+
 class InlineNodeHandler
 
   def self.add_to(dom_handler, tag, inline_node_style)
@@ -14,7 +16,7 @@ class InlineNodeHandler
   end
 
   def handle_node(inline_node, typeset_document)
-    line = document.current_page.current_box.current_line
+    line = typeset_document.current_page.current_box.current_line
     prev_font = @dom_handler.current_font
     font = TypesetFont.new(@style.sfnt_font, prev_font.size)
     line.push font.get_font_set_operation
@@ -25,13 +27,13 @@ class InlineNodeHandler
     @dom_handler.stack_font(font) do
       # inline_nodeの下はstringのみ
       inline_node.each do |string|
-        @dom_handler.dispatch_node_handling(string, document)
+        @dom_handler.dispatch_node_handling(string, typeset_document)
       end
     end
 
     @dom_handler.ignore_line_feed = prev_ignore_line_feed
 
-    line = document.current_page.current_box.current_line
+    line = typeset_document.current_page.current_box.current_line
     line.push prev_font.get_font_set_operation
   end
 

--- a/lib/inline_node_style.rb
+++ b/lib/inline_node_style.rb
@@ -1,0 +1,15 @@
+# インライン要素のスタイル
+
+class InlineNodeStyle
+
+  def initialize
+    @sfnt_font = nil
+    @ignore_line_feed = true
+    # FIXME: 本来はフォントサイズ指定できるべき
+    # 指定なしの場合継承するという仕組みも必要
+  end
+
+  attr_accessor :sfnt_font
+  attr_accessor :ignore_line_feed
+
+end

--- a/lib/markdown_parser.rb
+++ b/lib/markdown_parser.rb
@@ -9,13 +9,13 @@ require_relative 'typeset_padding'
 require_relative 'typeset_font'
 
 require_relative 'dom_handler'
+require_relative 'page_style'
+require_relative 'page_handler'
 require_relative 'block_node_style'
 require_relative 'block_node_handler'
 require_relative 'inline_node_style'
 require_relative 'inline_node_handler'
 require_relative 'text_handler'
-require_relative 'page_style'
-require_relative 'page_handler'
 
 class MarkdownParser
 
@@ -124,6 +124,10 @@ class MarkdownParser
   def setup_dom_handler
     dom_handler = DomHandler.new(@default_sfnt_font, @default_font_size)
 
+    # ページ
+    style = get_page_style
+    PageHandler.add_to(dom_handler, style)
+
     # header
     (1..6).each do |level|
       tag = "h#{level}"
@@ -164,16 +168,17 @@ class MarkdownParser
     # テキスト
     TextHandler.add_to(dom_handler)
 
-    # ページ
-    page_style = PageStyle.new
-    page_style.margin = @page_margin
-    page_style.padding = @page_padding
-    page_style.to_footer_gap = @to_footer_gap
-    page_style.footer_sfnt_font = @default_sfnt_font
-    page_style.footer_font_size = @default_font_size
-    PageHandler.add_to(dom_handler, page_style)
-
     dom_handler
+  end
+
+  def get_page_style
+    style = PageStyle.new
+    style.margin = @page_margin
+    style.padding = @page_padding
+    style.to_footer_gap = @to_footer_gap
+    style.footer_sfnt_font = @default_sfnt_font
+    style.footer_font_size = @default_font_size
+    style
   end
 
   def get_block_node_style(tag)

--- a/lib/page_handler.rb
+++ b/lib/page_handler.rb
@@ -1,0 +1,50 @@
+# ページを処理する
+
+require_relative 'typset_font'
+
+class PageHandler
+
+  def self.add_to(dom_handler, page_style)
+    handler = self.new(page_style)
+    dom_handler.register_page_handler(handler)
+    handler
+  end
+
+  def initialize(page_style)
+    @style = page_style
+  end
+
+  def create_new_page(typeset_document)
+    typeset_document.new_page(@style.margin, @style.padding, @style.to_footer_gap)
+    add_page_number(typeset_document)
+  end
+
+  private
+
+  def add_page_number(typeset_document)
+    page_number = typeset_document.page_count
+    is_odd_page = page_number % 2 == 1
+    page_number_str = page_number.to_s
+
+    footer = typeset_document.current_page.footer
+    line = footer.new_line
+    font = TypesetFont.new(@style.footer_sfnt_font, @sytle.footer_font_size)
+    # 右揃えできるように、フォント設定は最後に左端に追加する
+
+    page_number_str.each_char do |char|
+      line.push font.get_typeset_char(char)
+    end
+
+    if is_odd_page
+      space = line.allocated_width - line.width
+      space_as_char_count = space / @style.footer_font_size
+      line.unshift font.get_space(space_as_char_count)
+    end
+    line.unshift font.get_font_set_operation
+  end
+
+end
+
+if __FILE__ == $0
+  # FIXME: 動作確認のコードを追加すること
+end

--- a/lib/page_handler.rb
+++ b/lib/page_handler.rb
@@ -1,6 +1,6 @@
 # ページを処理する
 
-require_relative 'typset_font'
+require_relative 'typeset_font'
 
 class PageHandler
 
@@ -15,8 +15,9 @@ class PageHandler
   end
 
   def create_new_page(typeset_document)
-    typeset_document.new_page(@style.margin, @style.padding, @style.to_footer_gap)
+    new_page = typeset_document.new_page(@style.margin, @style.padding, @style.to_footer_gap)
     add_page_number(typeset_document)
+    new_page
   end
 
   private
@@ -28,7 +29,7 @@ class PageHandler
 
     footer = typeset_document.current_page.footer
     line = footer.new_line
-    font = TypesetFont.new(@style.footer_sfnt_font, @sytle.footer_font_size)
+    font = TypesetFont.new(@style.footer_sfnt_font, @style.footer_font_size)
     # 右揃えできるように、フォント設定は最後に左端に追加する
 
     page_number_str.each_char do |char|

--- a/lib/page_style.rb
+++ b/lib/page_style.rb
@@ -1,0 +1,22 @@
+# ページのスタイル
+
+require_relative 'typeset_margin'
+require_relative 'typeset_padding'
+
+class PageStyle
+
+  def initialize
+    @margin = TypesetMargin.zero_margin
+    @padding = TypesetPadding.zero_padding
+    @to_footer_gap = 0
+
+    # FIXME: フッタのレイアウトもDomHandlerに委譲したい
+    # そうすればこの設定は不要になる（ブロックの設定でOK）
+    @footer_sfnt_font = nil
+    @footer_font_size = nil
+  end
+
+  attr_accessor :margin, :padding, :to_footer_gap
+  attr_accessor :footer_sfnt_font, :footer_font_size
+
+end

--- a/lib/text_handler.rb
+++ b/lib/text_handler.rb
@@ -6,7 +6,7 @@ class TextHandler
 
   def self.add_to(dom_handler)
     handler = self.new(dom_handler)
-    dom_handler.register_text_handler(tag, handler)
+    dom_handler.register_text_handler(handler)
     handler
   end
 
@@ -53,7 +53,7 @@ class TextHandler
       # 改ページ処理
       if box.height > box.allocated_height
         last_line = box.pop
-        new_page = @dom_handler.create_new_page
+        new_page = @dom_handler.create_new_page(typeset_document)
         new_box = new_page.new_box(box.margin, box.padding, box.line_gap)
         new_line = new_box.new_line
         while char = last_line.shift

--- a/lib/text_handler.rb
+++ b/lib/text_handler.rb
@@ -1,0 +1,73 @@
+# テキストの処理
+
+class TextHandler
+
+  HANGING_CHARS = ")]}>,.;:!?）」』、。；：！？ぁぃぅぇぉっゃゅょァィゥェォッャュョ"
+
+  def self.add_to(dom_handler)
+    handler = self.new(dom_handler)
+    dom_handler.register_text_handler(tag, handler)
+    handler
+  end
+
+  def initialize(dom_handler)
+    @dom_handler = dom_handler
+  end
+
+  def handle_text(text, typeset_document, ignore_line_feed)
+    font = @dom_handler.current_font
+    text.each_char do |char|
+      if (char == "\n") && ignore_line_feed
+        next
+      end
+
+      page = typeset_document.current_page
+      box = page.current_box
+      line = box.current_line
+
+      if char != "\n"
+        line.push font.get_typeset_char(char)
+      else
+        if line.height == 0
+          # 高さを確保しておく
+          line.push font.get_strut
+        end
+        line = box.new_line
+        line.push font.get_font_set_operation
+      end
+
+      # 改行処理
+      if line.width > line.allocated_width
+        last_char = line.pop
+        if HANGING_CHARS.include?(last_char.to_s)
+          # 元に戻して改行しない
+          # FIXME: 複数文字続く場合、はみ出しが大きくなる
+          line.push last_char
+        else
+          new_line = typeset_document.current_page.current_box.new_line
+          new_line.push font.get_font_set_operation
+          new_line.push last_char
+        end
+      end
+
+      # 改ページ処理
+      if box.height > box.allocated_height
+        last_line = box.pop
+        new_page = @dom_handler.create_new_page
+        new_box = new_page.new_box(box.margin, box.padding, box.line_gap)
+        new_line = new_box.new_line
+        while char = last_line.shift
+          new_line.push char
+        end
+      end
+    end
+    # FIXME: rescue_font対応はまだ
+    # FIXME: 禁則処理とか
+    # FIXME: "「"で始まる場合は2分空きにしたり
+  end
+
+end
+
+if __FILE__ == $0
+  # FIXME: 動作確認のコードを追加すること
+end

--- a/lib/typeset_margin.rb
+++ b/lib/typeset_margin.rb
@@ -2,6 +2,10 @@
 
 class TypesetMargin
 
+  def self.zero_margin
+    @zero_margin ||= self.new
+  end
+
   def initialize(top: 0, right: 0, bottom: 0, left: 0)
     @top = top
     @right = right

--- a/lib/typeset_padding.rb
+++ b/lib/typeset_padding.rb
@@ -1,5 +1,18 @@
 # 組版パディング
 
-require_relative 'typeset_margin'
+class TypesetPadding
 
-TypesetPadding = TypesetMargin
+  def self.zero_padding
+    @zero_padding ||= self.new
+  end
+
+  def initialize(top: 0, right: 0, bottom: 0, left: 0)
+    @top = top
+    @right = right
+    @bottom = bottom
+    @left = left
+  end
+
+  attr_reader :top, :right, :bottom, :left
+
+end


### PR DESCRIPTION
DOMから組版オブジェクトへのパース処理を、ページ、ブロック、インライン、テキストに切り分けた。

close #4 