### PR TITLE
PDFオブジェクトのシリアライズ改善

### DIFF
--- a/lib/pdf_destination.rb
+++ b/lib/pdf_destination.rb
@@ -8,18 +8,21 @@ class PdfDestination
     @y = y
   end
 
-  def to_serialized_data(binder)
-    "[#{binder.get_ref(@page)} /XYZ #{@x} #{@y} null]"
+  def to_a(binder)
+    [binder.get_ref(@page), :XYZ, @x, @y, nil]
   end
 
 end
 
 if __FILE__ == $0
+  require_relative 'pdf_serialize_extension'
   require_relative 'pdf_object_binder'
+
+  using PdfSerializeExtension
 
   binder = PdfObjectBinder.new
   page = Object.new # dummy
 
   dest = PdfDestination.new(page, 100, 200)
-  puts dest.to_serialized_data(binder)
+  puts dest.to_a(binder).serialize
 end

--- a/lib/pdf_document.rb
+++ b/lib/pdf_document.rb
@@ -95,8 +95,6 @@ class PdfDocument
     end
 
     def add_destination(name, pdf_destination)
-      # nameはエンコードが必要な文字が含まれていないこと
-      # （あとで修正したい）
       @destinations[name] = pdf_destination
     end
 
@@ -283,10 +281,10 @@ if __FILE__ == $0
   document.add_image(PdfImageMock.new('image2'))
 
   document.add_destination("page1", PdfDestinationMock.new(page1))
-  document.add_destination("page2", PdfDestinationMock.new(page2))
+  document.add_destination("ページ2", PdfDestinationMock.new(page2))
 
   document.add_outline_item(PdfOutlineItemMock.new("outline1"))
-  document.add_outline_item(PdfOutlineItemMock.new("outline2"))
+  document.add_outline_item(PdfOutlineItemMock.new("アウトライン2"))
 
   binder = PdfObjectBinder.new
   document.root.attach_to(binder)

--- a/lib/pdf_object_binder.rb
+++ b/lib/pdf_object_binder.rb
@@ -39,7 +39,7 @@ class PdfObjectBinder
       serialized_data = <<~END_OF_SERIALIZED_DATA
         #{serialized_data.chomp}
         stream
-        #{stream_data.chomp}
+        #{stream_data}
         endstream
       END_OF_SERIALIZED_DATA
     end
@@ -101,7 +101,7 @@ if __FILE__ == $0
   root.add_child(node2)
   node1_1 = TreeNode.new
   node1.add_child(node1_1)
-  node1_1.content = <<~END_OF_CONTENT
+  node1_1.content = <<~END_OF_CONTENT.chomp
     hoge
     huga
   END_OF_CONTENT

--- a/lib/pdf_object_binder.rb
+++ b/lib/pdf_object_binder.rb
@@ -1,24 +1,55 @@
 # PDFオブジェクトバインダー
 # 各PDFオブジェクトはattach_to(binder)を実装し、binderにオブジェクトを結びつける
 
+require_relative 'pdf_serialize_extension'
+
 class PdfObjectBinder
+
+  using PdfSerializeExtension
+
+  class ObjectRef
+
+    def initialize(id)
+      @id = id
+    end
+
+    def serialize
+      "#{@id} 0 R"
+    end
+
+  end
 
   def initialize
     @id = {}
     @serialized_object = {}
   end
 
-  def attach(object, serialized_data)
+  def get_ref(object)
+    if object
+      id = get_id(object)
+      ObjectRef.new(id)
+    else
+      nil
+    end
+  end
+
+  def attach(object, data, stream_data=nil)
+    serialized_data = data.serialize
+    if stream_data
+      serialized_data = <<~END_OF_SERIALIZED_DATA
+        #{serialized_data.chomp}
+        stream
+        #{stream_data.chomp}
+        endstream
+      END_OF_SERIALIZED_DATA
+    end
+
     id = get_id(object)
     @serialized_object[id] ||= <<~END_OF_SERIALIZED_OBJECT
       #{id} 0 obj
       #{serialized_data.chomp}
       endobj
     END_OF_SERIALIZED_OBJECT
-  end
-
-  def get_ref(object)
-    "#{get_id(object)} 0 R"
   end
 
   def serialized_objects
@@ -39,25 +70,26 @@ if __FILE__ == $0
     def initialize
       @parent = nil
       @children = []
+      @content = nil
     end
 
-    def set_parent(parent)
-      @parent = parent
-    end
+    attr_writer :parent, :content
 
     def add_child(child)
       @children.push child
-      child.set_parent(self)
+      child.parent = self
     end
 
     def attach_to(binder)
       @children.each {|child| child.attach_to(binder) }
-      binder.attach(self, <<~END_OF_SERIALIZED_DATA)
-        <<
-          /Parent #{@parent.nil? ? "null" : binder.get_ref(@parent)}
-          /Children [#{@children.empty? ? "null" : @children.map{|child| binder.get_ref(child)}.join(' ')}]
-        >>
-      END_OF_SERIALIZED_DATA
+
+      parent_ref = binder.get_ref(@parent)
+      children_ref = @children.map{|child| binder.get_ref(child)}
+      dict = {
+        Parent: parent_ref,
+        Children: children_ref,
+      }
+      binder.attach(self, dict, @content)
     end
 
   end
@@ -69,6 +101,10 @@ if __FILE__ == $0
   root.add_child(node2)
   node1_1 = TreeNode.new
   node1.add_child(node1_1)
+  node1_1.content = <<~END_OF_CONTENT
+    hoge
+    huga
+  END_OF_CONTENT
 
   binder = PdfObjectBinder.new
   root.attach_to(binder)

--- a/lib/pdf_outline_item.rb
+++ b/lib/pdf_outline_item.rb
@@ -42,27 +42,24 @@ class PdfOutlineItem
       child.attach_to(binder)
     end
 
-    # FIXME: PDF用の基本型を作った方がよさそう
-    children_info = ""
+    outline_item_dict = {
+      Title: @title,
+      Dest: @destination_name.to_sym,
+      Parent: binder.get_ref(@parent),
+    }
+
+    outline_item_dict[:Prev] = binder.get_ref(@prev) if @prev
+    outline_item_dict[:Next] = binder.get_ref(@next) if @next
+
     unless @children.empty?
       first_item = @children[0]
       last_item = @children[-1]
-      children_info += "  /First #{binder.get_ref(first_item)}\n"
-      children_info += "  /Last #{binder.get_ref(last_item)}\n"
-      children_info += "  /Count 0\n"
+      outline_item_dict[:First] = binder.get_ref(first_item)
+      outline_item_dict[:Last] = binder.get_ref(last_item)
+      outline_item_dict[:Count] = 0
     end
 
-    bros_info = ""
-    bros_info += "  /Prev #{binder.get_ref(@prev)}\n" if @prev
-    bros_info += "  /Next #{binder.get_ref(@next)}\n" if @next
-
-    binder.attach(self, <<~END_OF_OUTLINE_ITEM)
-      <<
-        /Title (#{@title})
-        /Dest /#{@destination_name}
-        /Parent #{binder.get_ref(@parent)}
-      #{children_info}#{bros_info}>>
-    END_OF_OUTLINE_ITEM
+    binder.attach(self, outline_item_dict)
   end
 
 end

--- a/lib/pdf_outline_item.rb
+++ b/lib/pdf_outline_item.rb
@@ -9,8 +9,6 @@ class PdfOutlineItem
   end
 
   def initialize(title, destination_name)
-    # destination_nameはエンコードが必要な文字が含まれていないこと
-    # （あとで修正したい）
     @title = title
     @destination_name = destination_name
     @children = []

--- a/lib/pdf_page.rb
+++ b/lib/pdf_page.rb
@@ -35,14 +35,7 @@ class PdfPage
       stream = @operations.join("\n")
       length = stream.bytesize + "\n".bytesize
 
-      binder.attach(self, <<~END_OF_CONTENT)
-        <<
-          /Length #{length}
-        >>
-        stream
-        #{stream}
-        endstream
-      END_OF_CONTENT
+      binder.attach(self, {Length: length}, stream)
     end
 
   end
@@ -69,13 +62,12 @@ class PdfPage
   def attach_to(binder)
     @content.attach_to(binder)
 
-    binder.attach(self, <<~END_OF_PAGE)
-      <<
-        /Type /Page
-        /Parent #{binder.get_ref(@parent)}
-        /Contents [#{binder.get_ref(@content)}]
-      >>
-    END_OF_PAGE
+    page_dict = {
+      Type: :Page,
+      Parent: binder.get_ref(@parent),
+      Contents: [binder.get_ref(@content)],
+    }
+    binder.attach(self, page_dict)
   end
 
 end
@@ -124,11 +116,7 @@ if __FILE__ == $0
     def attach_to(binder)
       @pages.each{|page| page.attach_to(binder)}
 
-      binder.attach(self, <<~END_OF_DOCUMENT)
-        <<
-          /Type /Document
-        >>
-      END_OF_DOCUMENT
+      binder.attach(self, {Type: :Document})
     end
 
   end

--- a/lib/pdf_serialize_extension.rb
+++ b/lib/pdf_serialize_extension.rb
@@ -1,0 +1,103 @@
+# Rubyの型で表現したPDFオブジェクトのシリアライズ
+
+module PdfSerializeExtension
+
+  refine TrueClass do
+
+    def serialize
+      "true"
+    end
+
+  end
+
+  refine FalseClass do
+
+    def serialize
+      "false"
+    end
+
+  end
+
+  refine NilClass do
+
+    def serialize
+      "null"
+    end
+
+  end
+
+  refine Numeric do
+
+    def serialize
+      self.to_s
+    end
+
+  end
+
+  refine Symbol do
+
+    def serialize
+      # FIXME: マルチバイト対応
+      "/#{self}"
+    end
+
+  end
+
+  refine String do
+
+    def serialize
+      # FIXME: マルチバイト対応
+      "(#{self})"
+    end
+
+  end
+
+  refine Array do
+
+    def serialize
+      values = self.each.map(&:serialize).join(" ")
+      "[#{values}]"
+    end
+
+  end
+
+  refine Hash do
+
+    def serialize
+      if self.empty?
+        "<<>>"
+      else
+        pairs = self.each.map do |key, value|
+          serialized_key = key.to_sym.serialize
+          serialized_value = value.serialize
+          "#{serialized_key} #{serialized_value}"
+        end.join("\n")
+        "<<\n#{pairs}\n>>"
+      end
+    end
+
+  end
+
+end
+
+if __FILE__ == $0
+  using PdfSerializeExtension
+
+  data = {
+    a: true,
+    b: false,
+    c: nil,
+    d: 1,
+    e: 2.0,
+    f: :hoge,
+    g: "hoge",
+    h: [],
+    i: [1, 2, 3],
+    j: [true, false, nil, 1, 2.0, :hoge, "hoge"],
+    k: [[1, 2, 3], [4, [5, 6]]],
+    l: {},
+    m: {a: "aaa", b: "bbb"},
+  }
+
+  puts data.serialize
+end

--- a/lib/pdf_text.rb
+++ b/lib/pdf_text.rb
@@ -1,10 +1,12 @@
 # PDFテキスト
 
 require_relative 'hex_extension'
+require_relative 'pdf_serialize_extension'
 
 class PdfText
 
   using HexExtension
+  using PdfSerializeExtension
 
   def initialize(operations)
     @operations = operations
@@ -20,7 +22,7 @@ class PdfText
   def set_font(pdf_font, size)
     # NOTE: 今はここでpdf_fontに必要とされる機能がsfnt_fontと等しいので、
     # sfnt_fontも指定可能（本来はpdf_fontのみが指定されるべき）
-    @operations.push "  /#{pdf_font.id} #{size} Tf"
+    @operations.push "  #{pdf_font.id.to_sym.serialize} #{size} Tf"
     @font = pdf_font
   end
 

--- a/lib/test_pdf_output.rb
+++ b/lib/test_pdf_output.rb
@@ -254,17 +254,17 @@ end
 
 next_page = PdfPage.add_to(document)
 
-document.add_destination("page1", PdfDestination.new(page, 0.mm, 210.mm))
+document.add_destination("page 1", PdfDestination.new(page, 0.mm, 210.mm))
 document.add_destination("text", PdfDestination.new(page, 22.mm, 188.mm + 14.pt))
-document.add_destination("snowman", PdfDestination.new(page, 108.mm-25.pt, 40.mm+25.pt))
-document.add_destination("snowman_png", PdfDestination.new(page, 80.mm, 210.mm))
-document.add_destination("page2", PdfDestination.new(next_page, 0.mm, 210.mm))
+document.add_destination("image snowman", PdfDestination.new(page, 108.mm-25.pt, 40.mm+25.pt))
+document.add_destination("image snowman.png", PdfDestination.new(page, 80.mm, 210.mm))
+document.add_destination("page 2", PdfDestination.new(next_page, 0.mm, 210.mm))
 
-page1_outline = PdfOutlineItem.add_to(document, "Page 1", "page1")
-PdfOutlineItem.add_to(page1_outline, "text", "text")
-PdfOutlineItem.add_to(page1_outline, "snowman", "snowman")
-PdfOutlineItem.add_to(page1_outline, "snowman.png", "snowman_png")
-PdfOutlineItem.add_to(document, "Page 2", "page2")
+page1_outline = PdfOutlineItem.add_to(document, "ページ1", "page 1")
+PdfOutlineItem.add_to(page1_outline, "テキスト", "text")
+PdfOutlineItem.add_to(page1_outline, "雪だるま", "image snowman")
+PdfOutlineItem.add_to(page1_outline, "snowman.png", "image snowman.png")
+PdfOutlineItem.add_to(document, "ページ2", "page 2")
 
 writer = PdfWriter.new("output_test.pdf")
 writer.write(document)

--- a/lib/test_pdf_output.rb
+++ b/lib/test_pdf_output.rb
@@ -266,5 +266,5 @@ PdfOutlineItem.add_to(page1_outline, "snowman", "snowman")
 PdfOutlineItem.add_to(page1_outline, "snowman.png", "snowman_png")
 PdfOutlineItem.add_to(document, "Page 2", "page2")
 
-writer = PdfWriter.new("test.pdf")
+writer = PdfWriter.new("output_test.pdf")
 writer.write(document)


### PR DESCRIPTION
直接文字列データを作ってアタッチするのではなく、Rubyのオブジェクトで表現したデータをアタッチし、それをシリアライズするように変更した。
このなかでマルチバイト文字やエスケープが必要な文字への対処も実施した。（refs #7 ）

close #35 