### PR TITLE
PdfTextのインタフェース修正

### DIFF
--- a/lib/pdf_image.rb
+++ b/lib/pdf_image.rb
@@ -148,8 +148,8 @@ class PdfImage
         x += x_offset
         y += y_offset
 
-        @content.operations.push "#{x_scale} 0. 0. #{y_scale} #{x} #{y} cm"
-        @content.operations.push "#{image.id.to_sym.serialize} Do"
+        @content.add_operation "#{x_scale} 0. 0. #{y_scale} #{x} #{y} cm"
+        @content.add_operation "#{image.id.to_sym.serialize} Do"
       end
     end
 
@@ -162,7 +162,7 @@ class PdfImage
 
   attr_accessor :anchor, :dpi
 
-  def draw_on(content, &block)
+  def write_in(content, &block)
     pen = Pen.new(content, anchor: @anchor, dpi: @dpi)
     block.call(pen)
   end
@@ -173,38 +173,23 @@ if __FILE__ == $0
   require_relative 'pdf_page'
   require_relative 'pdf_object_binder'
 
-  class ResourceMock
+  content = PdfPage::Content.new
 
-    def initialize
-      @images = {}
-    end
-
-    def add_image(pdf_image)
-      @images[pdf_image.id] = pdf_image
-    end
-
-  end
-
-  resource = ResourceMock.new
-  page_content = PdfPage::Content.new
-
-  pdf_image = PdfImage::Png.load('christmas_snowman.png')
-  puts "path: #{pdf_image.path}"
-  puts "id  : #{pdf_image.id}"
-  puts "width : #{pdf_image.width}"
-  puts "height: #{pdf_image.height}"
-  puts "dpi   : #{pdf_image.dpi}"
-
-  resource.add_image(pdf_image)
+  png = PdfImage::Png.load('christmas_snowman.png')
+  puts "path: #{png.path}"
+  puts "id  : #{png.id}"
+  puts "width : #{png.width}"
+  puts "height: #{png.height}"
+  puts "dpi   : #{png.dpi}"
 
   image = PdfImage.new
-  image.draw_on(page_content) do |pen|
-    pen.paint pdf_image
+  image.write_in(content) do |pen|
+    pen.paint png
   end
 
   binder = PdfObjectBinder.new
-  pdf_image.attach_to(binder)
-  page_content.attach_to(binder)
+  png.attach_to(binder)
+  content.attach_to(binder)
 
   binder.serialized_objects.each do |serialized_object|
     puts serialized_object

--- a/lib/pdf_page.rb
+++ b/lib/pdf_page.rb
@@ -8,16 +8,18 @@ class PdfPage
       @operations = []
     end
 
-    attr_reader :operations
+    def add_operation(operation)
+      @operations.push operation
+    end
 
     def stack_graphic_state(&block)
-      @operations.push "q"
+      self.add_operation "q"
       block.call
-      @operations.push "Q"
+      self.add_operation "Q"
     end
 
     def move_origin(x, y)
-      @operations.push "1. 0. 0. 1. #{x} #{y} cm"
+      self.add_operation "1. 0. 0. 1. #{x} #{y} cm"
     end
 
     def attach_to(binder)

--- a/lib/pdf_page.rb
+++ b/lib/pdf_page.rb
@@ -1,7 +1,5 @@
 # PDFページ
 
-require_relative 'pdf_text'
-
 class PdfPage
 
   class Content
@@ -20,15 +18,6 @@ class PdfPage
 
     def move_origin(x, y)
       @operations.push "1. 0. 0. 1. #{x} #{y} cm"
-    end
-
-    def add_text(&block)
-      @operations.push "BT"
-
-      text = PdfText.new(@operations)
-      block.call(text)
-
-      @operations.push "ET"
     end
 
     def attach_to(binder)
@@ -132,41 +121,18 @@ end
 if __FILE__ == $0
   require 'uri'
 
-  require_relative 'sfnt_font'
-  require_relative 'pdf_font'
   require_relative 'length_extension'
   require_relative 'pdf_object_binder'
-
-  if ARGV.empty?
-    puts "[Font file list] ----------"
-    puts SfntFont.list
-    puts "---------------------------"
-    raise "No font file is specified."
-  end
-
-  filename = ARGV[0]
-  sfnt_font = SfntFont.load(filename)
-  pdf_font = PdfFont.new(sfnt_font)
 
   class PdfDocumentMock
 
     def initialize
       @pages = []
-      @resource = {}
-      def @resource.add_font(pdf_font)
-        self[pdf_font.id] = pdf_font
-      end
     end
-
-    attr_reader :resource
 
     def add_page(page)
       @pages.push page
       page.parent = self
-    end
-
-    def add_font(pdf_font)
-      @resource.add_font(pdf_font)
     end
 
     def attach_to(binder)
@@ -177,36 +143,10 @@ if __FILE__ == $0
 
   end
 
-  def put_tex(text, fontsize)
-    # base/plain.tex:\def\TeX{T\kern-.1667em\lower.5ex\hbox{E}\kern-.125emX}
-    text.putc char: 'T'
-    text.put_space -0.1667
-    text.set_text_rise(-fontsize * 0.5 * 0.5)
-    text.putc char: 'E'
-    text.set_text_rise 0
-    text.put_space -0.125
-    text.putc char: 'X'
-  end
-
   using LengthExtension
 
   document = PdfDocumentMock.new
-  document.add_font(pdf_font)
-
   page = PdfPage.add_to(document)
-  page.add_content do |content|
-    content.move_origin 22.mm, 188.mm
-    content.add_text do |text|
-      text.set_font pdf_font, 14
-      text.set_leading 16
-      ["ABCDE", "あいうえお", "斉斎齊齋", "\u{20B9F}\u{20D45}\u{20E6D}"].each do |str|
-        text.puts str
-      end
-      text.puts
-      put_tex(text, 14)
-      text.puts "グッバイしたい！"
-    end
-  end
 
   page.add_internal_link("id:ABC", [22.mm, 188.mm-14.pt, 22.mm+14.pt*3, 188.mm])
   page.add_internal_link("id:あいうえお", [22.mm, 188.mm-16.pt-14.pt, 22.mm+14.pt*5, 188.mm-16.pt], "あいうえお")

--- a/lib/pdf_text.rb
+++ b/lib/pdf_text.rb
@@ -5,60 +5,132 @@ require_relative 'pdf_serialize_extension'
 
 class PdfText
 
-  using HexExtension
-  using PdfSerializeExtension
+  DEFAULT_LEADING = 0
+  DEFAULT_TEXT_RISE = 0
 
-  def initialize(operations)
-    @operations = operations
-    @font = nil
+  class Pen
+
+    using HexExtension
+    using PdfSerializeExtension
+
+    def initialize(operations, font)
+      @operations = operations
+      @font = font
+    end
+
+    def set_font(pdf_font, size)
+      # NOTE: 今はここでpdf_fontに必要とされる機能がsfnt_fontと等しいので、
+      # sfnt_fontも指定可能（本来はpdf_fontのみが指定されるべき）
+      @operations.push "#{pdf_font.id.to_sym.serialize} #{size} Tf"
+      @font = pdf_font
+    end
+
+    def set_leading(size)
+      @operations.push "#{size} TL"
+    end
+
+    def set_text_rise(size)
+      @operations.push "#{size} Ts"
+    end
+
+    def puts(str="")
+      if str.nil? || str.empty?
+        @operations.push "T*"
+      else
+        encoded = @font.convert_to_gid(str).map(&:to_hex_str).join
+        @operations.push "<#{encoded}> Tj T*"
+      end
+    end
+
+    def putc(char: nil, gid: 0)
+      if char
+        gid = @font.convert_to_gid(char).first
+      end
+      encoded = gid.to_hex_str
+      @operations.push "<#{encoded}> Tj"
+    end
+
+    def put_space(n_chars)
+      # 正だと間が狭まり、負だと間が広がる
+      width = - n_chars * 1000
+      @operations.push "[#{width}] TJ"
+    end
+
+    # カーソルを行頭に戻す
+    # dx, dyが指定されていた場合、指定された分だけ行頭の位置を変更する
+    def return_cursor(dx: 0, dy: 0)
+      @operations.push "#{dx} #{dy} Td"
+    end
+
   end
 
-  # カーソルを行頭に戻す
-  # dx, dyが指定されていた場合、指定された分だけ行頭の位置を変更する
-  def return_cursor(dx: 0, dy: 0)
-    @operations.push "  #{dx} #{dy} Td"
-  end
-
-  def set_font(pdf_font, size)
-    # NOTE: 今はここでpdf_fontに必要とされる機能がsfnt_fontと等しいので、
-    # sfnt_fontも指定可能（本来はpdf_fontのみが指定されるべき）
-    @operations.push "  #{pdf_font.id.to_sym.serialize} #{size} Tf"
+  def initialize(pdf_font, font_size)
     @font = pdf_font
+    @size = font_size
+    @leading = DEFAULT_LEADING
+    @text_rise = DEFAULT_TEXT_RISE
   end
 
-  def set_leading(size)
-    @operations.push "  #{size} TL"
-  end
+  attr_accessor :font, :size, :leading, :text_rise
 
-  def set_text_rise(size)
-    @operations.push "  #{size} Ts"
-  end
+  def draw_on(content, &block)  # write_inがよさそう
+    content.stack_graphic_state do
+      operations = content.operations
+      pen = Pen.new(operations, @font)
 
-  def puts(str="")
-    if str.nil? || str.empty?
-      @operations.push "  T*"
-    else
-      encoded = @font.convert_to_gid(str).map(&:to_hex_str).join
-      @operations.push "  <#{encoded}> Tj T*"
+      operations.push "BT"
+
+      pen.set_font(@font, @size) if @font # FIXME: 本来@fontはnilでないべき
+      pen.set_leading(@leading) if @leading != DEFAULT_LEADING
+      pen.set_text_rise(@text_rise) if @text_rise != DEFAULT_TEXT_RISE
+
+      block.call(pen)
+
+      operations.push "ET"
     end
-  end
-
-  def putc(char: nil, gid: 0)
-    if char
-      gid = @font.convert_to_gid(char).first
-    end
-    encoded = gid.to_hex_str
-    @operations.push "  <#{encoded}> Tj"
-  end
-
-  def put_space(n_chars)
-    # 正だと間が狭まり、負だと間が広がる
-    width = - n_chars * 1000
-    @operations.push "  [#{width}] TJ"
   end
 
 end
 
 if __FILE__ == $0
-  # not yet
+  require_relative 'pdf_page'
+  require_relative 'sfnt_font'
+  require_relative 'pdf_font'
+  require_relative 'pdf_object_binder'
+
+  def put_tex(pen, fontsize)
+    # base/plain.tex:\def\TeX{T\kern-.1667em\lower.5ex\hbox{E}\kern-.125emX}
+    pen.putc char: 'T'
+    pen.put_space -0.1667
+    pen.set_text_rise(-fontsize * 0.5 * 0.5)
+    pen.putc char: 'E'
+    pen.set_text_rise 0
+    pen.put_space -0.125
+    pen.putc char: 'X'
+  end
+
+  page_content = PdfPage::Content.new
+
+  sfnt_font = SfntFont.load('ipaexm.ttf')
+  pdf_font = PdfFont.new(sfnt_font)
+  font_size = 14
+  line_gap = font_size / 2
+
+  text = PdfText.new(pdf_font, font_size)
+  text.leading = font_size + line_gap
+  text.draw_on(page_content) do |pen|
+    ["ABCDE", "あいうえお", "斉斎齊齋", "\u{20B9F}\u{20D45}\u{20E6D}"].each do |str|
+      pen.puts str
+    end
+    pen.puts
+    put_tex(pen, 14)
+    pen.puts "グッバイしたい！"
+  end
+
+  binder = PdfObjectBinder.new
+  page_content.attach_to(binder)
+
+  binder.serialized_objects.each do |serialized_object|
+    puts serialized_object
+  end
 end

--- a/lib/pdf_text.rb
+++ b/lib/pdf_text.rb
@@ -73,7 +73,7 @@ class PdfText
 
   attr_accessor :font, :size, :leading, :text_rise
 
-  def write_in(content, &block)  # write_inがよさそう
+  def write_in(content, &block)
     content.stack_graphic_state do
       pen = Pen.new(content, @font)
 

--- a/lib/typeset_box.rb
+++ b/lib/typeset_box.rb
@@ -3,6 +3,7 @@
 require 'forwardable'
 
 require_relative 'typeset_line'
+require_relative 'pdf_text'
 
 class TypesetBox
 
@@ -43,9 +44,10 @@ class TypesetBox
   def_delegators :@lines, :push, :pop, :unshift, :shift, :empty?
 
   def write_to(content)
-    content.add_text do |text|
+    text = PdfText.new(nil, 0)  # FIXME: 本来はフォントが定まっているべき
+    text.write_in(content) do |pen|
       init_ascender = @lines.empty? ? 0 : @lines[0].ascender
-      text.return_cursor(dx: @padding.left, dy: - @padding.top - init_ascender)
+      pen.return_cursor(dx: @padding.left, dy: - @padding.top - init_ascender)
 
       leadings = @lines.each_cons(2).map do |current_line, next_line|
         (- current_line.descender) + @line_gap + next_line.ascender
@@ -53,8 +55,8 @@ class TypesetBox
       leadings.push 0 # 番兵
 
       @lines.zip(leadings).each do |line, leading|
-        text.set_leading(leading)
-        line.write_to(text)
+        pen.set_leading(leading)
+        line.write_with(pen)
       end
     end
   end
@@ -66,40 +68,8 @@ if __FILE__ == $0
   require_relative 'typeset_font'
   require_relative 'typeset_margin'
   require_relative 'typeset_padding'
-
-  class ContentMock
-
-    class TextMock
-
-      def return_cursor(dx: 0, dy: 0)
-        STDOUT.puts "  [return_cursor] dx: #{dx}, dy: #{dy}"
-      end
-
-      def set_font(pdf_font, size)
-        STDOUT.puts "  [set_font] id: #{pdf_font.id}, size: #{size}"
-      end
-
-      def set_leading(size)
-        STDOUT.puts "  [set_leading] size: #{size}"
-      end
-
-      def puts(str="")
-        STDOUT.puts "  [puts]"
-      end
-
-      def putc(char: nil, gid: 0)
-        STDOUT.puts "  [putc] gid: #{gid}"
-      end
-
-    end
-
-    def add_text(&block)
-      puts "[add_text]"
-      text = TextMock.new
-      block.call(text)
-    end
-
-  end
+  require_relative 'pdf_page'
+  require_relative 'pdf_object_binder'
 
   sfnt_font = SfntFont.load('ipaexm.ttf')
   font_size = 14
@@ -154,7 +124,14 @@ if __FILE__ == $0
     "(top: #{box2.padding.top}, right: #{box2.padding.right}, "\
     "bottom: #{box2.padding.bottom}, left: #{box2.padding.left})"
 
-  content = ContentMock.new
+  content = PdfPage::Content.new
   box1.write_to(content)
   box2.write_to(content)
+
+  binder = PdfObjectBinder.new
+  content.attach_to(binder)
+
+  binder.serialized_objects.each do |serialized_object|
+    puts serialized_object
+  end
 end

--- a/lib/typeset_box.rb
+++ b/lib/typeset_box.rb
@@ -44,7 +44,8 @@ class TypesetBox
   def_delegators :@lines, :push, :pop, :unshift, :shift, :empty?
 
   def write_to(content)
-    text = PdfText.new(nil, 0)  # FIXME: 本来はフォントが定まっているべき
+    # FIXME: PdfTextを作るのはフォントが定まるもっと内側でやるべき
+    text = PdfText.new(nil, 0)
     text.write_in(content) do |pen|
       init_ascender = @lines.empty? ? 0 : @lines[0].ascender
       pen.return_cursor(dx: @padding.left, dy: - @padding.top - init_ascender)

--- a/lib/typeset_char.rb
+++ b/lib/typeset_char.rb
@@ -16,8 +16,8 @@ class TypesetChar
     @ascender - @descender
   end
 
-  def write_to(text)
-    text.putc(gid: @gid)
+  def write_with(pen)
+    pen.putc(gid: @gid)
   end
 
   def to_s
@@ -32,6 +32,7 @@ if __FILE__ == $0
   require_relative 'pdf_document'
   require_relative 'pdf_font'
   require_relative 'pdf_page'
+  require_relative 'pdf_text'
   require_relative 'pdf_object_binder'
 
   using LengthExtension
@@ -64,9 +65,9 @@ if __FILE__ == $0
   page = PdfPage.add_to(document)
   page.add_content do |content|
     content.move_origin 22.mm, 188.mm
-    content.add_text do |text|
-      text.set_font pdf_font, font_size
-      typeset_char.write_to(text)
+    text = PdfText.new(pdf_font, font_size)
+    text.write_in(content) do |pen|
+      typeset_char.write_with(pen)
     end
   end
 

--- a/lib/typeset_font.rb
+++ b/lib/typeset_font.rb
@@ -13,9 +13,9 @@ class TypesetFont
   attr_reader :sfnt_font, :size
 
   def get_font_set_operation
-    TypesetOperation.new do |text|
+    TypesetOperation.new do |pen|
       # FIXME: 本来はPdfFontが指定されるべき
-      text.set_font @sfnt_font, @size
+      pen.set_font @sfnt_font, @size
     end
   end
 
@@ -29,8 +29,8 @@ class TypesetFont
 
   def get_space(n_chars)
     width = @size * n_chars
-    TypesetOperation.new(width) do |text|
-      text.put_space n_chars
+    TypesetOperation.new(width) do |pen|
+      pen.put_space n_chars
     end
   end
 
@@ -45,7 +45,7 @@ end
 if __FILE__ == $0
   require_relative 'sfnt_font'
 
-  class TextMock
+  class PenMock
 
     def set_font(pdf_font, size)
       puts "[set_font] id: #{pdf_font.id}, size: #{size}"
@@ -78,8 +78,8 @@ if __FILE__ == $0
   puts "line width : #{line_width}"
   puts "line height: #{line_height}"
 
-  text = TextMock.new
+  pen = PenMock.new
   line.each do |item|
-    item.write_to(text)
+    item.write_with(pen)
   end
 end

--- a/lib/typeset_line.rb
+++ b/lib/typeset_line.rb
@@ -31,11 +31,11 @@ class TypesetLine
 
   def_delegators :@chars, :push, :pop, :unshift, :shift, :empty?
 
-  def write_to(text)
+  def write_with(pen)
     @chars.each do |char|
-      char.write_to(text)
+      char.write_with(pen)
     end
-    text.puts
+    pen.puts
   end
 
 end
@@ -44,7 +44,7 @@ if __FILE__ == $0
   require_relative 'sfnt_font'
   require_relative 'typeset_font'
 
-  class TextMock
+  class PenMock
 
     def set_font(pdf_font, size)
       STDOUT.puts "[set_font] id: #{pdf_font.id}, size: #{size}"
@@ -77,6 +77,6 @@ if __FILE__ == $0
   puts "line ascender  : #{line.ascender}"
   puts "line descender : #{line.descender}"
 
-  text = TextMock.new
-  line.write_to(text)
+  pen = PenMock.new
+  line.write_with(pen)
 end

--- a/lib/typeset_line.rb
+++ b/lib/typeset_line.rb
@@ -31,7 +31,7 @@ class TypesetLine
 
   def_delegators :@chars, :push, :pop, :unshift, :shift, :empty?
 
-  def write_with(pen)
+  def write_with(pen) # FIXME: write_to(content)であるべき
     @chars.each do |char|
       char.write_with(pen)
     end

--- a/lib/typeset_operation.rb
+++ b/lib/typeset_operation.rb
@@ -15,8 +15,8 @@ class TypesetOperation
     @ascender - @descender
   end
 
-  def write_to(obj)
-    @operation.call(obj)
+  def write_with(pen)
+    @operation.call(pen)
   end
 
 end
@@ -31,5 +31,5 @@ if __FILE__ == $0
   puts "ascender : #{operation.ascender}"
   puts "descender: #{operation.descender}"
 
-  operation.write_to("hoge")
+  operation.write_with("hoge")
 end

--- a/lib/typeset_page.rb
+++ b/lib/typeset_page.rb
@@ -107,50 +107,8 @@ if __FILE__ == $0
   require_relative 'typeset_font'
   require_relative 'typeset_margin'
   require_relative 'typeset_padding'
-
-  class ContentMock
-
-    class TextMock
-
-      def return_cursor(dx: 0, dy: 0)
-        STDOUT.puts "  [return_cursor] dx: #{dx}, dy: #{dy}"
-      end
-
-      def set_font(pdf_font, size)
-        STDOUT.puts "  [set_font] id: #{pdf_font.id}, size: #{size}"
-      end
-
-      def set_leading(size)
-        STDOUT.puts "  [set_leading] size: #{size}"
-      end
-
-      def puts(str="")
-        STDOUT.puts "  [puts]"
-      end
-
-      def putc(char: nil, gid: 0)
-        STDOUT.puts "  [putc] gid: #{gid}"
-      end
-
-    end
-
-    def stack_graphic_state(&block)
-      puts "[stack_graphic_state] begin"
-      block.call
-      puts "[stack_graphic_state] end"
-    end
-
-    def move_origin(x, y)
-      puts "[move_origin] x: #{x}, y: #{y}"
-    end
-
-    def add_text(&block)
-      puts "[add_text]"
-      text = TextMock.new
-      block.call(text)
-    end
-
-  end
+  require_relative 'pdf_page'
+  require_relative 'pdf_object_binder'
 
   sfnt_font = SfntFont.load('ipaexm.ttf')
   font_size = 14
@@ -215,6 +173,13 @@ if __FILE__ == $0
     "(top: #{box2.padding.top}, right: #{box2.padding.right}, "\
     "bottom: #{box2.padding.bottom}, left: #{box2.padding.left})"
 
-  content = ContentMock.new
+  content = PdfPage::Content.new
   page.write_to(content)
+
+  binder = PdfObjectBinder.new
+  content.attach_to(binder)
+
+  binder.serialized_objects.each do |serialized_object|
+    puts serialized_object
+  end
 end


### PR DESCRIPTION
PdfTextのインタフェースをPdfGraphic、PdfImageに合わせた。
ついてでにPdfPage::Contentの`@operations`に直接プッシュしてたけど、メソッド経由にした。
また、textだとdraw_onは変なので、他のも合わせてwrite_inに変更した。

組版オブジェクトの方では、本来はインラインボックスでテキストの設定を参照した方がいいが、とりあえずは現状のままで済むようにしている（text作成時のフォント設定はnilで、set_fontで指定される）。

close #18 