### PR TITLE
リンク関連の機能をPdfPageから分離

### DIFF
--- a/filelist.md
+++ b/filelist.md
@@ -129,9 +129,10 @@ vol.2 PDFのはなし
 ------------------------
 
 - `pdf_destination.rb`
+- `pdf_internal_link.rb`
+- `pdf_external_link.rb`
 - `pdf_outline_item.rb`
 - `pdf_document.rb` (再掲)
-- `pdf_page.rb` (再掲)
 - `test_pdf_output.rb` (要分割)
     - depend: `pdf_font`
     - depend: `length_extension`

--- a/lib/pdf_external_link.rb
+++ b/lib/pdf_external_link.rb
@@ -1,0 +1,40 @@
+# PDF外部リンク
+
+class PdfExternalLink
+
+  def initialize(uri, rect, alt=nil)
+    @uri = uri
+    @rect = rect
+    @alt = alt
+  end
+
+  def attach_to(binder)
+    link_dict = {
+      Subtype: :Link,
+      Rect: @rect,
+      Border: [0, 0, 0],
+      A: {S: :URI, URI: @uri},
+    }
+    link_dict[:Contents] = @alt if @alt
+
+    binder.attach(self, link_dict)
+  end
+
+end
+
+if __FILE__ == $0
+  require 'uri'
+
+  require_relative 'pdf_object_binder'
+
+  link1 = PdfExternalLink.new(URI.parse("http://www.hoge.huga"), [1, 2, 3, 4])
+  link2 = PdfExternalLink.new(URI.parse("https://www.hoge.huga/a/b/c"), [1, 2, 3, 4], "ほげ")
+
+  binder = PdfObjectBinder.new
+  link1.attach_to(binder)
+  link2.attach_to(binder)
+
+  binder.serialized_objects.each do |serialized_object|
+    puts serialized_object
+  end
+end

--- a/lib/pdf_graphic.rb
+++ b/lib/pdf_graphic.rb
@@ -299,7 +299,7 @@ if __FILE__ == $0
   require_relative 'pdf_page'
   require_relative 'pdf_object_binder'
 
-  content = PdfPage::Content.new(nil, nil)
+  content = PdfPage::Content.new
 
   path = PdfGraphic::Path.new do
     from [0, 0]

--- a/lib/pdf_image.rb
+++ b/lib/pdf_image.rb
@@ -173,7 +173,7 @@ if __FILE__ == $0
   require_relative 'pdf_page'
   require_relative 'pdf_object_binder'
 
-  content = PdfPage::Content.new(nil, nil)
+  content = PdfPage::Content.new
 
   png = PdfImage::Png.load('christmas_snowman.png')
   puts "path: #{png.path}"

--- a/lib/pdf_internal_link.rb
+++ b/lib/pdf_internal_link.rb
@@ -1,0 +1,38 @@
+# PDF内部リンク
+
+class PdfInternalLink
+
+  def initialize(destination_name, rect, alt=nil)
+    @destination_name = destination_name
+    @rect = rect
+    @alt = alt
+  end
+
+  def attach_to(binder)
+    link_dict = {
+      Subtype: :Link,
+      Rect: @rect,
+      Border: [0, 0, 0],
+      Dest: @destination_name.to_sym,
+    }
+    link_dict[:Contents] = @alt if @alt
+
+    binder.attach(self, link_dict)
+  end
+
+end
+
+if __FILE__ == $0
+  require_relative 'pdf_object_binder'
+
+  link1 = PdfInternalLink.new("id:ABC", [1, 2, 3, 4])
+  link2 = PdfInternalLink.new("id:あいうえお", [1, 2, 3, 4], "あいうえお")
+
+  binder = PdfObjectBinder.new
+  link1.attach_to(binder)
+  link2.attach_to(binder)
+
+  binder.serialized_objects.each do |serialized_object|
+    puts serialized_object
+  end
+end

--- a/lib/pdf_text.rb
+++ b/lib/pdf_text.rb
@@ -145,7 +145,7 @@ if __FILE__ == $0
     pen.putc char: 'X'
   end
 
-  content = PdfPage::Content.new(nil, nil)
+  content = PdfPage::Content.new
 
   sfnt_font = SfntFont.load('ipaexm.ttf')
   pdf_font = PdfFont.new(sfnt_font)

--- a/lib/test_pdf_output.rb
+++ b/lib/test_pdf_output.rb
@@ -11,6 +11,9 @@ require_relative 'pdf_page'
 require_relative 'pdf_graphic'
 require_relative 'pdf_image'
 require_relative 'pdf_text'
+require_relative 'pdf_internal_link'
+require_relative 'pdf_external_link'
+require_relative 'pdf_destination'
 require_relative 'pdf_outline_item'
 require_relative 'pdf_writer'
 
@@ -258,12 +261,12 @@ page.add_content do |content|
     pen.return_cursor dy: (- sfnt_font.descender * 10 / 1000.0) # descenderの分だけ上へ移動
     pen.puts "原点はここ"
   end
-
-  content.add_destination("page 1", 0.mm, 210.mm)
-  content.add_destination("text", 22.mm, 188.mm + 14.pt)
-  content.add_destination("image snowman", 108.mm-25.pt, 40.mm+25.pt)
-  content.add_destination("image snowman.png", 80.mm, 210.mm)
 end
+
+document.add_destination("page 1", PdfDestination.new(page, 0.mm, 210.mm))
+document.add_destination("text", PdfDestination.new(page, 22.mm, 188.mm + 14.pt))
+document.add_destination("image snowman", PdfDestination.new(page, 108.mm-25.pt, 40.mm+25.pt))
+document.add_destination("image snowman.png", PdfDestination.new(page, 80.mm, 210.mm))
 
 next_page = PdfPage.add_to(document)
 next_page.add_content do |content|
@@ -276,8 +279,8 @@ next_page.add_content do |content|
       y_offset = 188.mm
       dests.each_with_index do |dest, t|
         pen.puts "Link#{t}"
-        content.add_internal_link(
-          dest, [22.mm, y_offset, 22.mm + 40.pt, y_offset + 14.pt], dest)
+        next_page.add_link(
+          PdfInternalLink.new(dest, [22.mm, y_offset, 22.mm + 40.pt, y_offset + 14.pt], dest))
         y_offset -= 16.pt
       end
     end
@@ -289,14 +292,16 @@ next_page.add_content do |content|
     text.leading = 16
     text.write_in(content) do |pen|
       pen.puts "Yahoo"
-      content.add_external_link(
-        URI.parse("https://www.yahoo.co.jp/"),
-        [22.mm, 150.mm, 22.mm + 40.pt, 150.mm + 14.pt])
+      next_page.add_link(
+        PdfExternalLink.new(
+          URI.parse("https://www.yahoo.co.jp/"),
+          [22.mm, 150.mm, 22.mm + 40.pt, 150.mm + 14.pt]))
       pen.puts "TeXグッバイ本"
-      content.add_external_link(
-        URI.parse("https://www.yamaimo.dev/entry/TexGoodBye1"),
-        [22.mm, 150.mm - 16.pt, 22.mm + 90.pt, 150.mm - 16.pt + 14.pt],
-        "TeXグッバイしたい")
+      next_page.add_link(
+        PdfExternalLink.new(
+          URI.parse("https://www.yamaimo.dev/entry/TexGoodBye1"),
+          [22.mm, 150.mm - 16.pt, 22.mm + 90.pt, 150.mm - 16.pt + 14.pt],
+          "TeXグッバイしたい"))
     end
   end
 
@@ -313,9 +318,9 @@ next_page.add_content do |content|
       pen.puts "グッバイしたい！"
     end
   end
-
-  content.add_destination("page 2", 0.mm, 210.mm)
 end
+
+document.add_destination("page 2", PdfDestination.new(next_page, 0.mm, 210.mm))
 
 page1_outline = PdfOutlineItem.add_to(document, "ページ1", "page 1")
 PdfOutlineItem.add_to(page1_outline, "テキスト", "text")

--- a/lib/typeset_box.rb
+++ b/lib/typeset_box.rb
@@ -125,7 +125,7 @@ if __FILE__ == $0
     "(top: #{box2.padding.top}, right: #{box2.padding.right}, "\
     "bottom: #{box2.padding.bottom}, left: #{box2.padding.left})"
 
-  content = PdfPage::Content.new(nil, nil)
+  content = PdfPage::Content.new
   box1.write_to(content)
   box2.write_to(content)
 

--- a/lib/typeset_page.rb
+++ b/lib/typeset_page.rb
@@ -173,7 +173,7 @@ if __FILE__ == $0
     "(top: #{box2.padding.top}, right: #{box2.padding.right}, "\
     "bottom: #{box2.padding.bottom}, left: #{box2.padding.left})"
 
-  content = PdfPage::Content.new(nil, nil)
+  content = PdfPage::Content.new
   page.write_to(content)
 
   binder = PdfObjectBinder.new


### PR DESCRIPTION
リンク関連の機能がPdfPageに入っていると説明がしにくかった。
PdfPage自体はシンプルにした方がいい。

リンク関連の機能をPdfPageから追い出し、PdfPageに依存するようにして、分けて説明できるようにした。

なお、 #49 についてはリンクサービスのようなクラスを作って実現した方がよさそう。