### PR TITLE
文字幅がnilになりうる問題を修正

### DIFF
--- a/lib/hmtx_table.rb
+++ b/lib/hmtx_table.rb
@@ -30,6 +30,10 @@ class HmtxTable
 
   attr_reader :widths, :mode_width
 
+  def get_width(gid)
+    (gid < @widths.size) ? @widths[gid] : @widths[-1]
+  end
+
 end
 
 if __FILE__ == $0

--- a/lib/sfnt_font.rb
+++ b/lib/sfnt_font.rb
@@ -108,7 +108,7 @@ class SfntFont
 
   def_delegators :@cmap, :gid_cache, :convert_to_gid, :find_gid
 
-  def_delegators :@hmtx, :widths, :mode_width
+  def_delegators :@hmtx, :widths, :mode_width, :get_width
 
   def id
     "Font#{self.object_id}"
@@ -208,6 +208,6 @@ if __FILE__ == $0
     puts "string: #{str}"
     puts "  unicode: #{str.unpack('U*')}"
     puts "  glyph  : #{font.convert_to_gid(str)}"
-    puts "  width  : #{font.convert_to_gid(str).map{|gid| font.widths[gid]}}"
+    puts "  width  : #{font.convert_to_gid(str).map{|gid| font.get_width(gid)}}"
   end
 end

--- a/lib/sfnt_font_collection.rb
+++ b/lib/sfnt_font_collection.rb
@@ -138,6 +138,6 @@ if __FILE__ == $0
     puts "string: #{str}"
     puts "  unicode: #{str.unpack('U*')}"
     puts "  glyph  : #{font.convert_to_gid(str)}"
-    puts "  width  : #{font.convert_to_gid(str).map{|gid| font.widths[gid]}}"
+    puts "  width  : #{font.convert_to_gid(str).map{|gid| font.get_width(gid)}}"
   end
 end

--- a/lib/test_sfnt_font.rb
+++ b/lib/test_sfnt_font.rb
@@ -29,7 +29,7 @@ puts "script     : #{font.script?}"
 ["ABCDE", "あいうえお", "斉斎齊齋"].each do |str|
   cids = str.unpack('U*')
   gids = font.convert_to_gid(str)
-  widths = gids.map{|gid| font.widths[gid]}
+  widths = gids.map{|gid| font.get_width(gid)}
   puts "string: #{str}"
   puts "  cid  : #{cids}"
   puts "  gid  : #{gids}"

--- a/lib/test_sfnt_font_collection.rb
+++ b/lib/test_sfnt_font_collection.rb
@@ -48,7 +48,7 @@ puts "script     : #{font.script?}"
 ["ABCDE", "あいうえお", "斉斎齊齋"].each do |str|
   cids = str.unpack('U*')
   gids = font.convert_to_gid(str)
-  widths = gids.map{|gid| font.widths[gid]}
+  widths = gids.map{|gid| font.get_width(gid)}
   puts "string: #{str}"
   puts "  cid  : #{cids}"
   puts "  gid  : #{gids}"

--- a/lib/typeset_char.rb
+++ b/lib/typeset_char.rb
@@ -42,7 +42,7 @@ if __FILE__ == $0
 
   char = 'あ'
   gid = sfnt_font.convert_to_gid(char).first
-  width = sfnt_font.widths[gid] * font_size / 1000.0
+  width = sfnt_font.get_width(gid) * font_size / 1000.0
   ascender = sfnt_font.ascender * font_size / 1000.0
   descender = sfnt_font.descender * font_size / 1000.0
 

--- a/lib/typeset_font.rb
+++ b/lib/typeset_font.rb
@@ -21,7 +21,7 @@ class TypesetFont
 
   def get_typeset_char(char)
     gid = @sfnt_font.convert_to_gid(char).first
-    width = @sfnt_font.widths[gid] * @size / 1000.0
+    width = @sfnt_font.get_width(gid) * @size / 1000.0
     ascender = @sfnt_font.ascender * @size / 1000.0
     descender = @sfnt_font.descender * @size / 1000.0
     TypesetChar.new(char, gid, width, ascender, descender)


### PR DESCRIPTION
フォントのGIDが`HheaTable#hmetrics_count`以上だと文字幅が`nil`になる問題があった。

`HmtxTable`に`get_width(gid)`を追加し、GIDが`HheaTable#hmetrics_count`以上の場合は`widths`の最後の値を返すように修正した。

close #53 